### PR TITLE
remove unused notification state (untraceable) from docs and code

### DIFF
--- a/examples/Sofortueberweisung.php
+++ b/examples/Sofortueberweisung.php
@@ -21,7 +21,6 @@ $Sofortueberweisung->setAbortUrl('YOUR_ABORT_URL');
 // $Sofortueberweisung->setNotificationUrl('YOUR_NOTIFICATION_URL', 'pending');
 // $Sofortueberweisung->setNotificationUrl('YOUR_NOTIFICATION_URL', 'received');
 // $Sofortueberweisung->setNotificationUrl('YOUR_NOTIFICATION_URL', 'refunded');
-// $Sofortueberweisung->setNotificationUrl('YOUR_NOTIFICATION_URL', 'untraceable');
 $Sofortueberweisung->setNotificationUrl('YOUR_NOTIFICATION_URL');
 //$Sofortueberweisung->setCustomerprotection(true);
 

--- a/src/Sofort/SofortLib/AbstractWrapper.php
+++ b/src/Sofort/SofortLib/AbstractWrapper.php
@@ -662,7 +662,7 @@ abstract class AbstractWrapper
      * Sets the notification Email-address and it's attributes
      *
      * @param string $notificationAddress
-     * @param string $notifyOn Comma separated (notification on: loss|pending|received|refunded|untraceable)
+     * @param string $notifyOn Comma separated (notification on: loss|pending|received|refunded)
      * @return AbstractWrapper $this
      */
     public function setNotificationEmail($notificationAddress, $notifyOn = '')
@@ -675,7 +675,7 @@ abstract class AbstractWrapper
      * Sets the notification URL and it's attributes
      *
      * @param string $notificationAddress
-     * @param string $notifyOn Comma separated (notification on: loss|pending|received|refunded|untraceable)
+     * @param string $notifyOn Comma separated (notification on: loss|pending|received|refunded)
      * @return AbstractWrapper $this
      */
     public function setNotificationUrl($notificationAddress, $notifyOn = '')
@@ -806,14 +806,14 @@ abstract class AbstractWrapper
      *
      * @param string $notificationAddress email address or url
      * @param string $notificationType (url|email)
-     * @param string $notifyOn Comma separated (notification on: loss|pending|received|refunded|untraceable)
+     * @param string $notifyOn Comma separated (notification on: loss|pending|received|refunded)
      * @return AbstractWrapper $this
      */
     protected function _setNotification($notificationAddress, $notificationType, $notifyOn = '')
     {
         if ($notifyOn) {
             $notifyOnArrayIn = explode(',', $notifyOn);
-            $notifyOnDefault = array('loss', 'pending', 'received', 'refunded', 'untraceable');
+            $notifyOnDefault = array('loss', 'pending', 'received', 'refunded');
             $notifyOnArray = array();
             
             if (is_array($notifyOnArrayIn)) {

--- a/src/Sofort/SofortLib/TransactionData.php
+++ b/src/Sofort/SofortLib/TransactionData.php
@@ -561,7 +561,7 @@ class TransactionData extends AbstractWrapper
     /**
      * Request for transactions with certain status
      *
-     * @param string $status (loss|pending|received|refunded|untraceable)
+     * @param string $status (loss|pending|received|refunded)
      * @return TransactionData
      */
     public function setStatus($status)

--- a/tests/unit/TransactionDataTest.php
+++ b/tests/unit/TransactionDataTest.php
@@ -1398,7 +1398,6 @@ class TransactionDataTest extends TestWrapper
                     'pending',
                     'received',
                     'refunded',
-                    'untraceable'
                 )
             )
         );


### PR DESCRIPTION
removed 'untraceable' as state from docs, examples and tests
