### PR TITLE
Error Handling String

### DIFF
--- a/src/Sofort/SofortLib/AbstractWrapper.php
+++ b/src/Sofort/SofortLib/AbstractWrapper.php
@@ -271,12 +271,12 @@ abstract class AbstractWrapper
     public function getErrorsString($paymentMethod = 'all', $message = array())
     {
         $errors = $this->getErrors($paymentMethod, $message);
-        
         $strings = array();
+        
         foreach ($errors as $error) {
-            $str = 'Error: ' . $error['code'] . ':' . $error['message'];
-            $strings[] = $str . '.';
+            $strings[] = 'Error: ' . $error['code'] . ':' . $error['message'] . '.';
         }
+        
         return implode(' ', $strings);
     }
     

--- a/src/Sofort/SofortLib/AbstractWrapper.php
+++ b/src/Sofort/SofortLib/AbstractWrapper.php
@@ -260,6 +260,26 @@ abstract class AbstractWrapper
         return $returnArray;
     }
     
+    /**
+     * Get all errors in a string
+     *
+     * @param string $paymentMethod - 'all', 'sr', 'su' (default "all")
+     * @param array $message (optional) response array
+     * @return string  A string representation of the errors array.
+     * 
+     */
+    public function getErrorsString($paymentMethod = 'all', $message = array())
+    {
+        $errors = $this->getErrors($paymentMethod, $message);
+        
+        $strings = array();
+        foreach ($errors as $error) {
+            $str = 'Error: ' . $error['code'] . ':' . $error['message'];
+            $strings[] = $str . '.';
+        }
+        return implode(' ', $strings);
+    }
+    
     
     /**
      * Getter for logHandler


### PR DESCRIPTION
I have added a method to retrieve all errors as a string. This would make logging&debugging a lot easier.

Please consider using this method in the example files, too. (I was not aware that several errors can occur at the same time, and the first error didn't help me at all - so the suggested getError()-method was not helpful for debugging.)
